### PR TITLE
Fix typo in Content API query.

### DIFF
--- a/docs/examples/content-api/multisite.md
+++ b/docs/examples/content-api/multisite.md
@@ -268,7 +268,7 @@ The key comes in the new website-specific query support. Here's an Elasticsearch
     "bool": {
       "must": [
         {
-          "term": { "revison.published": 1 }
+          "term": { "revision.published": 1 }
         },
         {
           "nested": {


### PR DESCRIPTION
Copying this code resulted in a support issue, so we should fix it.